### PR TITLE
guix.scm: add patch-extension-path phase.

### DIFF
--- a/guix.scm
+++ b/guix.scm
@@ -56,6 +56,23 @@
                         #:recursive? #t
                         #:select? (git-predicate %source-dir)))
     (build-system gnu-build-system)
+    (arguments
+     (list
+      #:phases
+      #~(modify-phases %standard-phases
+          (add-after 'unpack 'patch-extension-path
+            (lambda* (#:key outputs #:allow-other-keys)
+              (substitute* (find-files "." "\\.scm")
+                (("\\(load-extension \"libguile-udev\" *\"(.*)\"\\)" _ o)
+                 (string-append
+                  (object->string
+                   `(or (false-if-exception
+                         (load-extension "libguile-udev" ,o))
+                        (load-extension
+                         ,(string-append
+                           #$output
+                           "/lib/libguile-udev.so")
+                         ,o)))))))))))
     (native-inputs
      (list autoconf
            automake


### PR DESCRIPTION
```
Backtrace:
In ice-9/command-line.scm:
   185:19 19 (_ #<input: string 7f3cba07a850>)
In unknown file:
          18 (eval (use-modules (udev udev)) #<directory (guile-user…>)
In ice-9/eval.scm:
   721:20 17 (primitive-eval (use-modules (udev udev)))
In ice-9/psyntax.scm:
  1229:36 16 (expand-top-sequence (#<syntax:unknown file:1:0 (use-…>) …)
  1221:19 15 (parse _ (("placeholder" placeholder)) ((top) #(# # …)) …)
   259:10 14 (parse _ (("placeholder" placeholder)) (()) _ c&e (eval) …)
In ice-9/boot-9.scm:
  3935:20 13 (process-use-modules _)
   222:17 12 (map1 (((udev udev))))
  3936:31 11 (_ ((udev udev)))
  3327:17 10 (resolve-interface (udev udev) #:select _ #:hide _ # _ # …)
In ice-9/threads.scm:
    390:8  9 (_ _)
In ice-9/boot-9.scm:
  3253:13  8 (_)
In ice-9/threads.scm:
    390:8  7 (_ _)
In ice-9/boot-9.scm:
  3544:20  6 (_)
   2836:4  5 (save-module-excursion #<procedure 7f3cba071150 at ice-…>)
  3564:26  4 (_)
In unknown file:
           3 (primitive-load-path "udev/udev" #<procedure 7f3cba08d7…>)
           2 (load-extension "libguile-udev" "init_udev")
In system/foreign-library.scm:
   190:25  1 (load-foreign-library _ #:extensions _ # _ #:search-path …)
In unknown file:
           0 (dlopen "libguile-udev.so" 1)

ERROR: In procedure dlopen:
In procedure dlopen: file "libguile-udev.so", message "libguile-udev.so: cannot open shared object file: No such file or directory"
```

after this PR, allow `guix shell -f guix.scm guile -- guile -c '(use-modules (udev udev))'` work,
