### PR TITLE
[DRAFT] libguile-udev: Replace undocumented SCM_NEWSMOB with scm_new_smob.

### DIFF
--- a/libguile-udev/udev-device-type.c
+++ b/libguile-udev/udev-device-type.c
@@ -65,12 +65,10 @@ gudev_device_t* make_gudev_device()
  */
 SCM udev_device_to_scm(SCM udev, struct udev_device *udev_device)
 {
-    SCM smob;
     gudev_device_t* udd = make_gudev_device();
     udd->udev_device = udev_device;
     udd->udev        = udev;
-    SCM_NEWSMOB(smob, udev_device_tag, udd);
-    return smob;
+    return scm_new_smob(udev_device_tag, udd);
 }
 
 /**

--- a/libguile-udev/udev-hwdb-type.c
+++ b/libguile-udev/udev-hwdb-type.c
@@ -72,12 +72,10 @@ gudev_hwdb_t* make_gudev_hwdb()
  */
 SCM udev_hwdb_to_scm(SCM udev, struct udev_hwdb *udev_hwdb)
 {
-     SCM smob;
      gudev_hwdb_t* uhd = make_gudev_hwdb();
      uhd->udev      = udev;
      uhd->udev_hwdb = udev_hwdb;
-     SCM_NEWSMOB(smob, udev_hwdb_tag, uhd);
-     return smob;
+     return scm_new_smob(udev_hwdb_tag, uhd);
 }
 
 gudev_hwdb_t* gudev_hwdb_from_scm(SCM x)

--- a/libguile-udev/udev-monitor-type.c
+++ b/libguile-udev/udev-monitor-type.c
@@ -77,7 +77,6 @@ gudev_monitor_t* make_udev_monitor()
  */
 SCM gudev_monitor_to_scm(SCM udev, struct udev_monitor *udev_monitor)
 {
-    SCM smob;
     gudev_monitor_t* umd = make_udev_monitor();
     umd->udev             = udev;
     umd->udev_monitor     = udev_monitor;
@@ -87,9 +86,7 @@ SCM gudev_monitor_to_scm(SCM udev, struct udev_monitor *udev_monitor)
     umd->scanner_callback = SCM_BOOL_F;
     pthread_mutex_init(&umd->lock, NULL);
 
-    SCM_NEWSMOB(smob, udev_monitor_tag, umd);
-
-    return smob;
+    return scm_new_smob(udev_monitor_tag, umd);
 }
 
 /**

--- a/libguile-udev/udev-type.c
+++ b/libguile-udev/udev-type.c
@@ -65,12 +65,11 @@ SCM_DEFINE_1(gudev_is_udev_p, "udev?", (SCM x),
  */
 SCM udev_to_scm(struct udev *udev)
 {
-    SCM smob;
     gudev_t* ud = (gudev_t *) scm_gc_malloc(sizeof(gudev_t),
                                             "udev");
     ud->udev = udev;
-    SCM_NEWSMOB(smob, udev_tag, ud);
-    return smob;
+
+    return scm_new_smob(udev_tag, ud);
 }
 
 /**
@@ -86,12 +85,11 @@ gudev_t* gudev_from_scm(SCM x)
 
 SCM_DEFINE_0(udev_make_udev, "make-udev", "Make an Udev handle.")
 {
-    SCM smob;
     gudev_t* ud = (gudev_t *) scm_gc_malloc(sizeof (gudev_t),
                                             "udev");
     ud->udev = udev_new();
-    SCM_NEWSMOB(smob, udev_tag, ud);
-    return smob;
+
+    return scm_new_smob(udev_tag, ud);
 }
 
 /**


### PR DESCRIPTION
* libguile-udev/udev-device-type.c (udev_device_to_scm): Replace SCM_NEWSMOB with scm_new_smob.
* libguile-udev/udev-hwdb-type.c (udev_hwdb_to_scm): Likewise.
* libguile-udev/udev-monitor-type.c (gudev_monitor_to_scm): Likewise.
* libguile-udev/udev-type.c (udev_to_scm, make-udev): Likewise.

This currently causes the following compilation warnings:

```
udev-device-type.c: In function 'udev_device_to_scm':
udev-device-type.c:71:42: warning: passing argument 2 of 'scm_new_smob' makes integer from pointer without a cast [-Wint-conversion]
   71 |     return scm_new_smob(udev_device_tag, udd);
      |                                          ^~~
      |                                          |
      |                                          gudev_device_t * {aka struct gudev_device *}
In file included from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/threads.h:29,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/async.h:25,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile.h:35,
                 from udev-device-type.c:21:
/gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/smob.h:135:41: note: expected 'scm_t_bits' {aka 'long unsigned int'} but argument is of type 'gudev_device_t *' {aka 'struct gudev_device *'}
  135 | scm_new_smob (scm_t_bits tc, scm_t_bits data)
      |                              ~~~~~~~~~~~^~~~
  CC       libguile_udev_la-udev-monitor-main.lo
  CC       libguile_udev_la-udev-monitor-type.lo
  CC       libguile_udev_la-udev-type.lo
  CC       libguile_udev_la-udev-hwdb-type.lo
  CC       libguile_udev_la-udev-hwdb-func.lo
udev-type.c: In function 'udev_to_scm':
udev-type.c:72:35: warning: passing argument 2 of 'scm_new_smob' makes integer from pointer without a cast [-Wint-conversion]
   72 |     return scm_new_smob(udev_tag, ud);
      |                                   ^~
      |                                   |
      |                                   gudev_t * {aka struct gudev *}
In file included from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/threads.h:29,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/async.h:25,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile.h:35,
                 from udev-type.c:21:
/gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/smob.h:135:41: note: expected 'scm_t_bits' {aka 'long unsigned int'} but argument is of type 'gudev_t *' {aka 'struct gudev *'}
  135 | scm_new_smob (scm_t_bits tc, scm_t_bits data)
      |                              ~~~~~~~~~~~^~~~
udev-type.c: In function 'udev_make_udev':
udev-type.c:92:35: warning: passing argument 2 of 'scm_new_smob' makes integer from pointer without a cast [-Wint-conversion]
   92 |     return scm_new_smob(udev_tag, ud);
      |                                   ^~
      |                                   |
      |                                   gudev_t * {aka struct gudev *}
In file included from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/threads.h:29,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/async.h:25,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile.h:35,
                 from udev-type.c:21:
/gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/smob.h:135:41: note: expected 'scm_t_bits' {aka 'long unsigned int'} but argument is of type 'gudev_t *' {aka 'struct gudev *'}
  135 | scm_new_smob (scm_t_bits tc, scm_t_bits data)
      |                              ~~~~~~~~~~~^~~~
udev-monitor-type.c: In function 'gudev_monitor_to_scm':
udev-monitor-type.c:89:43: warning: passing argument 2 of 'scm_new_smob' makes integer from pointer without a cast [-Wint-conversion]
   89 |     return scm_new_smob(udev_monitor_tag, umd);
      |                                           ^~~
      |                                           |
      |                                           gudev_monitor_t * {aka struct gudev_monitor *}
In file included from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/threads.h:29,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/async.h:25,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile.h:35,
                 from udev-monitor-type.c:21:
/gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/smob.h:135:41: note: expected 'scm_t_bits' {aka 'long unsigned int'} but argument is of type 'gudev_monitor_t *' {aka 'struct gudev_monitor *'}
  135 | scm_new_smob (scm_t_bits tc, scm_t_bits data)
      |                              ~~~~~~~~~~~^~~~
  CC       libguile_udev_la-udev-hwdb-main.lo
udev-hwdb-type.c: In function 'udev_hwdb_to_scm':
udev-hwdb-type.c:78:41: warning: passing argument 2 of 'scm_new_smob' makes integer from pointer without a cast [-Wint-conversion]
   78 |      return scm_new_smob(udev_hwdb_tag, uhd);
      |                                         ^~~
      |                                         |
      |                                         gudev_hwdb_t * {aka struct gudev_hwdb *}
In file included from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/threads.h:29,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/async.h:25,
                 from /gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile.h:35,
                 from common.h:24,
                 from udev-hwdb-type.c:21:
/gnu/store/4gvgcfdiz67wv04ihqfa8pqwzsb0qpv5-guile-3.0.9/include/guile/3.0/libguile/smob.h:135:41: note: expected 'scm_t_bits' {aka 'long unsigned int'} but argument is of type 'gudev_hwdb_t *' {aka 'struct gudev_hwdb *'}
  135 | scm_new_smob (scm_t_bits tc, scm_t_bits data)
      |                              ~~~~~~~~~~~^~~~
  CCLD     libguile-udev.la
```

But otherwise appear to work fine.  I don't know which cast to apply to resolve these, hence marking as DRAFT.