### PR TITLE
Do not apply udev-monitor-set-timeout! to #f values.

### DIFF
--- a/modules/udev/monitor.scm
+++ b/modules/udev/monitor.scm
@@ -27,6 +27,7 @@
 ;;; Code:
 
 (define-module (udev monitor)
+  #:use-module (srfi srfi-1)
   #:export (udev-monitor
 	    udev-monitor?
 	    %make-udev-monitor
@@ -63,7 +64,9 @@ seconds and microseconds, respectively.  If TIMEOUT-USEC, is used, TIMEOUT-SEC
 must also have a value, else it is ignored, as for the 'secs' and 'usecs'
 argument of Guile's 'select' procedure."
   (let ((monitor (%make-udev-monitor udev)))
-    (udev-monitor-set-timeout!  monitor timeout-sec timeout-usec)
+    (apply udev-monitor-set-timeout!
+           (cons monitor
+                 (filter-map identity (list timeout-sec timeout-usec))))
     (udev-monitor-set-callback! monitor callback)
     (udev-monitor-set-error-callback! monitor error-callback)
     (when filter


### PR DESCRIPTION
This is a follow-up to commit 980fe40, which changed the default timeout-sec and timeout-usec values to #f, with the behavior of waiting indefinitely for an event.

* modules/udev/monitor.scm (make-udev-monitor): Filter out arguments whose values are #f.